### PR TITLE
nginx/cerbot implemented. d-c will build/run site

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ www.ohmydawg.co.uk (currently dogsite) will become this repo (Aiming for end of 
 * Each dog has their profile page displaying details of themselves along with photos
 * Each dog can delete their own photos and edit their details
 * Possibly dogs message eachother to plan walks
+
+## Commands to run site 
+
+* grep -rl 'VAR1' ./data/nginx/app.conf | xargs sudo sed -i 's/VAR1/<Domain-Name>/g'
+* sudo DOMAIN="<Domain-Name>" EMAIL="<Email>" ./init-letsencrypt.sh
+* docker-compose up
+

--- a/data/nginx/app.conf
+++ b/data/nginx/app.conf
@@ -1,0 +1,39 @@
+server {
+    listen 80;
+    server_name VAR1;
+    server_tokens off;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+    if ($host = VAR1) {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name VAR1;
+    server_tokens off;
+
+    ssl_certificate /etc/letsencrypt/live/VAR1/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/VAR1/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+        proxy_pass  http://reactapp:3000;
+    }
+    location /api {
+        proxy_pass http://server:5000;
+        client_max_body_size 1000M;
+    }
+    location /photos {
+        proxy_pass http://server:5000;
+        client_max_body_size 1000M;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,35 @@
 version: '3.6'
 services:
+ nginx:
+  image: nginx:1.15-alpine
+  restart: unless-stopped
+  depends_on:
+   - reactapp
+   - server
+  ports:
+   - 80:80
+   - 443:443
+  volumes:
+   - ./data/nginx:/etc/nginx/conf.d
+   - ./data/certbot/conf:/etc/letsencrypt
+   - ./data/certbot/www:/var/www/certbot
+  command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
+ certbot:
+  image: certbot/certbot
+  restart: unless-stopped
+  volumes:
+   - ./data/certbot/conf:/etc/letsencrypt
+   - ./data/certbot/www:/var/www/certbot
+  entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
  server:
-  build: /home/ubuntu/ohmydawg/back-end/.
+  build: ./back-end/.
   ports:
    - 5000:5000
-  networks:
-   - ohmydawg
   volumes:
    - ohmydawgData:/home/ubuntu/ohmydawg/back-end/
  reactapp:
-  build: /home/ubuntu/ohmydawg/front-end/.
+  build: ./front-end/.
   ports:
    - 3000:3000
-  networks:
-   - ohmydawg
-networks:
- ohmydawg:
 volumes:
  ohmydawgData:
-  # volumes now makes data persistant.... maybe look at having a file just for saved data now
-  # once nginx image is built need to include details in here too

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+if ! [ -x "$(command -v docker-compose)" ]; then
+  echo 'Error: docker-compose is not installed.' >&2
+  exit 1
+fi
+
+domains=(${DOMAIN})
+rsa_key_size=4096
+data_path="./data/certbot"
+email="${EMAIL}" # Adding a valid address is strongly recommended
+staging=0 # Set to 1 if you're testing your setup to avoid hitting request limits
+
+if [ -d "$data_path" ]; then
+  read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
+  if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
+    exit
+  fi
+fi
+
+
+if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
+  echo "### Downloading recommended TLS parameters ..."
+  mkdir -p "$data_path/conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  echo
+fi
+
+echo "### Creating dummy certificate for $domains ..."
+path="/etc/letsencrypt/live/$domains"
+mkdir -p "$data_path/conf/live/$domains"
+docker-compose run --rm --entrypoint "\
+  openssl req -x509 -nodes -newkey rsa:$rsa_key_size -days 1\
+    -keyout '$path/privkey.pem' \
+    -out '$path/fullchain.pem' \
+    -subj '/CN=localhost'" certbot
+echo
+
+
+echo "### Starting nginx ..."
+docker-compose up --force-recreate -d nginx
+echo
+
+echo "### Deleting dummy certificate for $domains ..."
+docker-compose run --rm --entrypoint "\
+  rm -Rf /etc/letsencrypt/live/$domains && \
+  rm -Rf /etc/letsencrypt/archive/$domains && \
+  rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
+echo
+
+
+echo "### Requesting Let's Encrypt certificate for $domains ..."
+#Join $domains to -d args
+domain_args=""
+for domain in "${domains[@]}"; do
+  domain_args="$domain_args -d $domain"
+done
+
+# Select appropriate email arg
+case "$email" in
+  "") email_arg="--register-unsafely-without-email" ;;
+  *) email_arg="--email $email" ;;
+esac
+
+# Enable staging mode if needed
+if [ $staging != "0" ]; then staging_arg="--staging"; fi
+
+docker-compose run --rm --entrypoint "\
+  certbot certonly --webroot -w /var/www/certbot \
+    $staging_arg \
+    $email_arg \
+    $domain_args \
+    --rsa-key-size $rsa_key_size \
+    --agree-tos \
+    --force-renewal" certbot
+echo
+
+echo "### Reloading nginx ..."
+docker-compose exec nginx nginx -s reload


### PR DESCRIPTION
Nginx and certbot images are implemented with docker-compose and with 3 commands the site can be run

`grep -rl 'VAR1' ./data/nginx/app.conf | xargs sudo sed -i 's/VAR1/<Domain-Name>/g'`
^ Will look up all VAR1 in ./data/nginx/app.conf and change to chosen domain name
`sudo DOMAIN="<Domain-Name>" EMAIL="<Email>" ./init-letsencrypt.sh`
^ This builds/pulls images in docker-compose, create certificates 
`docker-compose` up`
^ starts the containers





