### PR TITLE
command added so setup of site is now 2 commands

### DIFF
--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -11,6 +11,9 @@ data_path="./data/certbot"
 email="${EMAIL}" # Adding a valid address is strongly recommended
 staging=0 # Set to 1 if you're testing your setup to avoid hitting request limits
 
+echo 'editting app.conf'
+grep -rl "VAR1" ./data/nginx/app.conf | xargs sudo sed -i "s/VAR1/$domains/g"
+
 if [ -d "$data_path" ]; then
   read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
   if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then


### PR DESCRIPTION
`grep -rl "VAR1" ./data/nginx/app.conf | xargs sudo sed -i "s/VAR1/$domains/g"`
Is now in init-letsencrypt.sh which means the site can be set up with just 2 commands.